### PR TITLE
Lesson 63. Const Member Functions

### DIFF
--- a/Source/ObstacleAssault/MovingPlatform.cpp
+++ b/Source/ObstacleAssault/MovingPlatform.cpp
@@ -53,12 +53,12 @@ void AMovingPlatform::RotatePlatform(float DeltaTime)
     UE_LOG(LogTemp, Display, TEXT("%s rotating"), *GetName());
 }
 
-bool AMovingPlatform::ShouldPlatformReturn()
+bool AMovingPlatform::ShouldPlatformReturn() const
 {
     return GetDistanceMoved() > MoveDistance;
 }
 
-float AMovingPlatform::GetDistanceMoved()
+float AMovingPlatform::GetDistanceMoved() const
 {
     return FVector::Dist(StartLocation, GetActorLocation());
 }

--- a/Source/ObstacleAssault/MovingPlatform.h
+++ b/Source/ObstacleAssault/MovingPlatform.h
@@ -36,6 +36,6 @@ private:
     void MovePlatform(float DeltaTime);
     void RotatePlatform(float DeltaTime);
 
-    bool ShouldPlatformReturn();
-    float GetDistanceMoved();
+    bool ShouldPlatformReturn() const;
+    float GetDistanceMoved() const;
 };


### PR DESCRIPTION
what did I learn? const keyword makes it so you cannot modify values inside of a const function, you also cannot call functions that arent marked as const, it is good practice to make functions that do not modify values such as get functions to be made const